### PR TITLE
Add ABI pretty printer #1

### DIFF
--- a/abiprinter.py
+++ b/abiprinter.py
@@ -1,0 +1,37 @@
+#!/usr/bin/python3
+
+import sys
+import json
+from console import Console
+from jsonprinter import Items, JsonPrinter
+
+structItems = Items().line() \
+    .add('name', 'base').line() \
+    .add('fields', items=Items(atnewline=True, items=Items().add('name','type')).line()).line()
+
+indexItems = Items().line() \
+    .add('name', 'unique').line() \
+    .add('orders', items=Items(atnewline=True, items=Items().add('field','order')).line()).line()
+
+tableItems = Items().line() \
+    .add('name', 'type').add('scope_type', optional=True).line() \
+    .add('indexes', items=Items(items=indexItems).line()).line()
+
+variantItems = Items().line() \
+    .add('name').line() \
+    .add('types', items=Items(atnewline=True).line()).line()
+
+abiItems = Items(atnewline=True).line() \
+    .add('____comment', optional=True).line() \
+    .add('version').line() \
+    .add('types', items=Items(atnewline=True, items=Items().add('new_type_name','type')).line()).line() \
+    .add('structs', items=Items(items=structItems).line()).line() \
+    .add('actions', items=Items(atnewline=True, items=Items().add('name','type')).line()).line() \
+    .add('events', items=Items(atnewline=True, items=Items().add('name','type')).line()).line() \
+    .add('tables', items=Items(items=tableItems).line()).line() \
+    .add('variants', items=Items(items=variantItems).line()).line()
+
+abi = json.load(sys.stdin)
+
+printer = JsonPrinter(Console())
+print(printer.format(abiItems, abi))

--- a/jsonprinter.py
+++ b/jsonprinter.py
@@ -127,7 +127,7 @@ class JsonPrinter:
             else: hasHidden = True; break
 
         if hasHidden: result += '...'
-        if items.newline: result += '\n'+intend
+        if items.newline and not firstItem: result += '\n'+intend
         result += '}'
         return result
 
@@ -140,7 +140,7 @@ class JsonPrinter:
                 result += self.__printItem('', item, intend+self.shift*' ', flags, firstItem=firstItem)
                 firstItem = False
 
-        if items.newline: result += '\n'+intend
+        if items.newline and not firstItem: result += '\n'+intend
         result += ']'
         return result
 


### PR DESCRIPTION
Resolve #1 

Allow to print ABI file with less lines combining some members in one line. Result example:
```
{
    "version": "cyberway::abi/1.1", 
    "types": [], 
    "structs": [{
            "name": "state_info", "base": "", 
            "fields": [
                {"name": "id", "type": "uint64"}, 
                {"name": "last_schedule_increase", "type": "time_point_sec"}, 
                {"name": "block_num", "type": "uint32"}, 
                {"name": "target_emission_per_block", "type": "int64"}, 
                {"name": "funds", "type": "int64"}, 
                {"name": "last_propose_block_num", "type": "uint32"}, 
                {"name": "required_producers_num", "type": "uint16"}, 
                {"name": "last_producers_num", "type": "uint16"}
            ]
        }, {
            "name": "balance_struct", "base": "", 
            "fields": [
                {"name": "account", "type": "name"}, 
                {"name": "amount", "type": "int64"}
            ]
        }, {
            "name": "onblock", "base": "", 
            "fields": [
                {"name": "producer", "type": "name"}
            ]
        }
    ], 
    "actions": [
        {"name": "onblock", "type": "onblock"}
    ], 
    "events": [], 
    "tables": [{
            "name": "governstate", "type": "state_info", "scope_type": "", 
            "indexes": [{
                    "name": "primary", "unique": true, 
                    "orders": [
                        {"field": "id", "order": "asc"}
                    ]
                }
            ]
        }, {
            "name": "balance", "type": "balance_struct", "scope_type": "", 
            "indexes": [{
                    "name": "primary", "unique": true, 
                    "orders": [
                        {"field": "account", "order": "asc"}
                    ]
                }
            ]
        }
    ], 
    "variants": [], 
    "abi_extensions": [], 
    "error_messages": []
}

```